### PR TITLE
Add entrypoint script override to write environment variables to file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,10 @@ RUN yarn build
 
 
 FROM nginx as production
+COPY docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
+# write environment variables to config file and start
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh", "/docker-entrypoint.sh"]
+
 COPY --from=build-deps /opt/app/dist /usr/share/nginx/html
+
+CMD ["nginx","-g","daemon off;"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+repo_path="$(cd "$(dirname "$0")" && pwd)"
+cmdname="$(basename "$0")"
+
+usage() {
+    cat << USAGE >&2
+Usage:
+    $cmdname command
+
+    Docker entrypoint script
+    Wrapper script that executes docker-related tasks before running given command
+
+USAGE
+    exit 1
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+
+write_env_to_json() {
+    # write project-specific environment variables to app config file
+    local json_file="$1"
+
+    # only write environment variables containing "REACT_" or "VUE_"
+    local json_contents="{$(printenv | grep -e REACT_ -e VUE_ | sed 's/^\|$/"/g' | sed 's|=|":"|' | paste -sd, -)}"
+    echo "$json_contents" > "$json_file"
+}
+
+
+write_env_to_json /usr/share/nginx/html/env.json
+
+
+echo $cmdname complete
+echo executing given command $@
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,7 @@ write_env_to_json() {
     # write project-specific environment variables to app config file
     local json_file="$1"
 
-    # only write environment variables containing "REACT_" or "VUE_"
+    # only write environment variables frontend will read (beginning with "REACT_" or "VUE_")
     local json_contents="{$(printenv | grep -e REACT_ -e VUE_ | sed 's/^\|$/"/g' | sed 's|=|":"|' | paste -sd, -)}"
     echo "$json_contents" > "$json_file"
 }


### PR DESCRIPTION
- At container startup, write env vars starting with `VUE_` (or `REAC_`) to a file for frontend consumption (`/env.json`)
