### PR TITLE
Upload FHIR on Startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,15 @@ RUN yarn build
 
 
 FROM nginx as production
+
+# TODO remove when FHIR resources are PUT after SoF launch
+# python3 needed for upload.py
+RUN \
+    apt-get update && \
+    apt-get install --quiet --quiet --no-install-recommends \
+        python3 python3-requests
+COPY src/fhir /var/opt/
+
 COPY docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 # write environment variables to config file and start
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh", "/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,6 +35,17 @@ write_env_to_json() {
 write_env_to_json /usr/share/nginx/html/env.json
 
 
+# TODO remove when FHIR resources are PUT after SoF launch
+if [ -n "$FHIR_SERVER" ]; then
+    echo Uploading files:
+    find /var/opt
+    # run python upload script
+    /var/opt/upload.py "$FHIR_SERVER"
+else
+    echo FHIR_SERVER not set, skipping file upload
+fi
+
+
 echo $cmdname complete
 echo executing given command $@
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eu
+set -e
 
 repo_path="$(cd "$(dirname "$0")" && pwd)"
 cmdname="$(basename "$0")"


### PR DESCRIPTION
Call `upload.py` at container startup, if `FHIR_SERVER` environment variable set


See [Set FHIR_SERVER for upload.py script](https://github.com/uwcirg/dcw-environments/pull/13)