### PR TITLE
Fixup FHIR Resources

### DIFF
--- a/src/fhir/1_Questionnaire-MINICOG.json
+++ b/src/fhir/1_Questionnaire-MINICOG.json
@@ -36,7 +36,6 @@
     {
       "linkId": "minicog-question1-instruction",
       "type": "display",
-      "text": "",
       "readOnly": true,
       "_text": {
         "extension": [
@@ -56,7 +55,6 @@
     {
       "linkId": "minicog-question2-instruction",
       "type": "display",
-      "text": "",
       "readOnly": true,
       "_text": {
         "extension": [
@@ -95,7 +93,6 @@
     {
       "linkId": "minicog-total-score-explanation",
       "type": "display",
-      "text": "",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression",
@@ -119,7 +116,6 @@
     {
       "linkId": "minicog-questionnaire-footnote",
       "type": "display",
-      "text": "",
       "readOnly":true,
       "_text": {
         "extension": [

--- a/src/fhir/1_Questionnaire-MINICOG.json
+++ b/src/fhir/1_Questionnaire-MINICOG.json
@@ -8,10 +8,12 @@
   "id": "CIRG-MINICOG",
   "url": "http://www.cdc.gov/ncbddd/fasd/minicog",
   "name": "MINICOG",
-  "identifier": {
-    "system": "http://hl7.org/fhir/uv/sdc/NamingSystem/questionnaire-ids",
-    "value": "MINICOG"
-  },
+  "identifier": [
+    {
+      "system": "http://hl7.org/fhir/uv/sdc/NamingSystem/questionnaire-ids",
+      "value": "MINICOG"
+    }
+  ],
   "status": "draft",
   "title": "Mini Cognitive Assessment",
   "subjectType": [

--- a/src/fhir/1_Questionnaire-PHQ9.json
+++ b/src/fhir/1_Questionnaire-PHQ9.json
@@ -3,10 +3,12 @@
   "id": "CIRG-PHQ9",
   "name": "phq9",
   "url": "http://www.cdc.gov/ncbddd/fasd/phq9",
-  "identifier": {
-    "system": "http://hl7.org/fhir/uv/sdc/NamingSystem/questionnaire-ids",
-    "value": "phq9"
-  },
+  "identifier": [
+    {
+      "system": "http://hl7.org/fhir/uv/sdc/NamingSystem/questionnaire-ids",
+      "value": "phq9"
+    }
+  ],
   "meta": {
     "versionId": "1",
     "lastUpdated": "2022-03-31T17:37:39.938+00:00",


### PR DESCRIPTION
- Fixup FHIR resource issues identified by Hapi warnings
- Remove empty `text` fields
  - Hapi emits below warning otherwise
  - [Non-standard](http://hl7.org/fhir/R4B/questionnaire-definitions.html#Questionnaire.item.text) Hapi restriction?


`WARN  c.u.fhir.parser.LenientErrorHandler [LenientErrorHandler.java:87] [element="text"] Invalid attribute value "": Attribute value must not be empty ("")`


Fixed:
```
Found incorrect type for element identifier - Expected ARRAY and found OBJECT
[element="text"] Invalid attribute value "": Attribute value must not be empty ("")
[element="text"] Invalid attribute value "": Attribute value must not be empty ("")
[element="text"] Invalid attribute value "": Attribute value must not be empty ("")
[element="text"] Invalid attribute value "": Attribute value must not be empty ("")
Found incorrect type for element identifier - Expected ARRAY and found OBJECT
```