### PR TITLE
fix logic for presenting ADL-IADL

### DIFF
--- a/src/cql/CirgLibraryQuestionnaireLogic_DCW.json
+++ b/src/cql/CirgLibraryQuestionnaireLogic_DCW.json
@@ -3693,11 +3693,20 @@
                "else" : {
                   "type" : "If",
                   "condition" : {
-                     "type" : "IsTrue",
-                     "operand" : {
-                        "name" : "dcw_cog_level_1",
-                        "type" : "ExpressionRef"
-                     }
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "IsTrue",
+                        "operand" : {
+                           "name" : "dcw_cog_level_2",
+                           "type" : "ExpressionRef"
+                        }
+                     }, {
+                        "type" : "IsTrue",
+                        "operand" : {
+                           "name" : "dcw_care_partner_present",
+                           "type" : "ExpressionRef"
+                        }
+                     } ]
                   },
                   "then" : {
                      "type" : "Tuple",

--- a/src/cql/upstream-external/CirgLibraryQuestionnaireLogic_DCW.cql
+++ b/src/cql/upstream-external/CirgLibraryQuestionnaireLogic_DCW.cql
@@ -359,7 +359,8 @@ define PresentQnr_CIRG_SLUMS:
 define PresentQnr_CIRG_ADL_IADL:
   // check if there are already questionnaire responses for today
   if Length(CIRG_ADL_IADL_Responses_Today) >= 1 then null
-  else if dcw_cog_level_1 is true then {
+  // dementia dx or failed MINICOG score AND care partner present
+  else if dcw_cog_level_2 is true and dcw_care_partner_present is true then {
     questionnaireId: 'CIRG-ADL-IADL',
     scheduledTiming: Scheduled_Timing,
     status: 'scheduled'

--- a/test/cases/dcwApply/dcw_cog_level_1.yml
+++ b/test/cases/dcwApply/dcw_cog_level_1.yml
@@ -8,4 +8,3 @@ data:
 results:
   PresentQnr_CIRG_MINICOG: $should exist
   PresentQnr_CIRG_ECOG12: $should exist
-  PresentQnr_CIRG_ADL_IADL: $should exist

--- a/test/cases/dcwApply/minicog_cog_level_2_score1_wpartner.yml
+++ b/test/cases/dcwApply/minicog_cog_level_2_score1_wpartner.yml
@@ -68,3 +68,4 @@ results:
   PresentQnr_CIRG_SLUMS: $should exist
   CarePartner_Questionnaire: $should exist
   IsCarePartnerPresent: true
+  PresentQnr_CIRG_ADL_IADL: $should exist


### PR DESCRIPTION
Per feedback and chat with Sie-ce:
Update logic for presenting ADL-IADL:
The criteria for presenting ADL-IADL is now:

- Care partner is present
- Patient has a dementia diagnosis OR a failed MINICOG score